### PR TITLE
Change to 3.0-rc3

### DIFF
--- a/Aliases/tidb-server@3.0
+++ b/Aliases/tidb-server@3.0
@@ -1,0 +1,1 @@
+../Formula/tidb-server.rb

--- a/Formula/tidb-server@2.1.rb
+++ b/Formula/tidb-server@2.1.rb
@@ -1,4 +1,4 @@
-class TidbServerAT20 < Formula
+class TidbServerAT21 < Formula
   desc "TiDB is a MySQL compatible distributed database"
   homepage "https://www.pingcap.com/en/"
   url "https://github.com/pingcap/tidb.git",

--- a/Formula/tidb-server@2.1.rb
+++ b/Formula/tidb-server@2.1.rb
@@ -1,4 +1,4 @@
-class TidbServer < Formula
+class TidbServerAT20 < Formula
   desc "TiDB is a MySQL compatible distributed database"
   homepage "https://www.pingcap.com/en/"
   url "https://github.com/pingcap/tidb.git",

--- a/Formula/tidb-server@2.1.rb
+++ b/Formula/tidb-server@2.1.rb
@@ -2,8 +2,8 @@ class TidbServer < Formula
   desc "TiDB is a MySQL compatible distributed database"
   homepage "https://www.pingcap.com/en/"
   url "https://github.com/pingcap/tidb.git",
-      :tag      => "v3.0.0-rc.3",
-      :revision => "07af45fc30278fa00e89b8ebf4ad6a6c536fbbfd"
+      :tag      => "v2.1.13",
+      :revision => "6b5b1a6802f9b8f5a22d8aab24ac80729331e1bc"
 
   depends_on "go" => :build
 
@@ -12,6 +12,10 @@ class TidbServer < Formula
     inreplace "config/config.go", "/tmp/tidb", var/"tidb"
     inreplace "tidb-server/main.go", "/tmp/tidb", var/"tidb"
 
+    # Removing the go.sum file
+    # fixes a problem in go mod hashes:
+    # https://stackoverflow.com/questions/54133789/go-modules-checksum-mismatch
+    rm "go.sum"
     system "make", "server"
     bin.install "bin/tidb-server"
   end


### PR DESCRIPTION
This PR adds support for:
```
brew install tidb-server@3.0 (an alias to tidb-server)
brew install tidb-server@2.1
brew install tidb-server (now at 3.0)
```

The point release for 2.1 is bumped to the latest, and 3.0 uses rc3.