### PR TITLE
Support brew install TiUP

### DIFF
--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -36,7 +36,7 @@ class Tiup < Formula
     # cretae tiup home directory
     tiup_home = home_path+"/"+".tiup"
     # install
-    system "sh install.sh | grep -v 'shell' | grep -v 'profile' | grep -v 'playground' | grep -v '='"
+    system "sh install.sh"
 
     # set tiup bin
     bin_path = tiup_home+"/bin/tiup"

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -42,7 +42,7 @@ class Tiup < Formula
       Update all installed components to the latest version
       
       ===============================================
-        Have a try:     tiup update --self && tiup update cluster
+        Have a try:     tiup update --all
       ===============================================
 
       Questions? https://docs.pingcap.com/tidb/stable/tiup-component-management

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -2,10 +2,10 @@ class Tiup < Formula
   desc "TiDB is a MySQL compatible distributed database, and tiup is a component manager for testing and using TiDB locally."
   homepage "https://www.pingcap.com"
   url "https://github.com/pingcap/tiup.git",
-      tag:      "v1.8.1",
-      revision: "559b99d0acb7d07acddbb8cda0304b0f27c6ec1e"
+      tag:      "v1.9.0",
+      revision: "18747cd26c1877c28281b13b51e0437056a14d28"
   license "Apache-2.0"
-  version "v1.8.1"
+  version "v1.9.0"
 
   depends_on "go" => :build
   # depends_on "curl" => :build
@@ -24,7 +24,7 @@ class Tiup < Formula
   def caveats
     s = <<~EOS
       Install TiUP successfully!  Please run:
-      (If you have a private mirror source, Please replace https://tiup-mirrors.pingcap.com/root.json to your private mirror source:)\
+      (If you have a private mirror source, Please replace https://tiup-mirrors.pingcap.com/root.json to your private mirror source:)
 
       ======================================================================
       ! Must do:      mkdir -p ~/.tiup/bin && curl https://tiup-mirrors.pingcap.com/root.json -o ~/.tiup/bin/root.json

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -24,21 +24,6 @@ class Tiup < Formula
     #system "echo 'Installed path: ", tiup_home ,"'"
     # end
   end
-  
-  def upgrade
-    o = <<~EOS
-
-      Update all installed components to the latest version
-      
-      ===============================================
-        Have a try:     tiup update --all
-      ===============================================
-
-      Questions? https://docs.pingcap.com/tidb/stable/tiup-component-management
-
-    EOS
-    
-  end
 
   def caveats
     s = <<~EOS

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -1,27 +1,23 @@
 class Tiup < Formula
   desc "TiDB is a MySQL compatible distributed database, and tiup is a component manager for testing and using TiDB locally."
   homepage "https://www.pingcap.com"
-  url "https://tiup-mirrors.pingcap.com/install.sh"
-  sha256 "2784762fa6151539ecae3a975c21996036f4d7c82a4efe1f57dbefd1579c4b98"
+  url "https://github.com/pingcap/tiup.git",
+      tag:      "v1.8.1",
+      revision: "559b99d0acb7d07acddbb8cda0304b0f27c6ec1e"
   license "Apache-2.0"
-  version "1.8.1"
+  version "v1.8.1"
 
-  # depends_on "go" => :build
-  depends_on "curl" => :build
+  depends_on "go" => :build
+  # depends_on "curl" => :build
   depends_on "mysql-client" => :optional
 
   def install
-    # set tiup home
-    tiup_home = ENV["HOME"]+"/"+".tiup"
-
     # install
-    system "sh install.sh"
-
+    system "make", "tiup"
     # set tiup bin
-    bin_path = tiup_home+"/bin/tiup"
-    #root_path = tiup_home+"/bin/root.json"
+    bin_path = "bin/tiup"
     bin.install bin_path
-    #system "echo 'Installed path: ", tiup_home ,"'"
+ 
     # end
   end
 
@@ -57,15 +53,8 @@ class Tiup < Formula
 
 
   test do
-    # `test do` will create, run in and delete a temporary directory.
-    #
-    # This test will fail and we won't accept that! For Homebrew/homebrew-core
-    # this will need to be a test that verifies the functionality of the
-    # software. Run the test with `brew test tiup`. Options passed
-    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
-    #
     # The installed folder is not in the path, so use the entire path to any
     # executables being tested: `system "#{bin}/program", "do", "something"`.
-    system "tiup" "--version"
+    system "#{bin}/tiup" "--version"
   end
 end

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -4,7 +4,7 @@ class Tiup < Formula
   url "https://tiup-mirrors.pingcap.com/install.sh"
   sha256 "2784762fa6151539ecae3a975c21996036f4d7c82a4efe1f57dbefd1579c4b98"
   license "Apache-2.0"
-  version "1.8.0"
+  version "1.8.1"
 
   # depends_on "go" => :build
   depends_on "curl" => :build

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -3,7 +3,7 @@ class Tiup < Formula
   homepage "https://www.pingcap.com"
   url "https://github.com/pingcap/tiup.git",
       tag:      "v1.9.0",
-      revision: "18747cd26c1877c28281b13b51e0437056a14d28"
+      revision: "382d0e95f1c68e2fe272266d77abd57f273f7f31"
   license "Apache-2.0"
   version "v1.9.0"
 

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -1,26 +1,71 @@
 class Tiup < Formula
   desc "TiDB is a MySQL compatible distributed database, and tiup is a component manager for testing and using TiDB locally."
-  homepage "https://www.pingcap.com/en/"
-  url "https://github.com/pingcap-incubator/tiup.git",
-    :tag => "v0.0.1"
+  homepage "https://www.pingcap.com"
+  url "https://tiup-mirrors.pingcap.com/install.sh"
+  sha256 "2784762fa6151539ecae3a975c21996036f4d7c82a4efe1f57dbefd1579c4b98"
+  license "Apache-2.0"
+  version "1.7.0"
 
-  depends_on "go" => :build
+  # depends_on "go" => :build
+  depends_on "curl" => :build
   depends_on "mysql-client" => :optional
 
   def install
-    system "make", "EXTRA_LDFLAGS=-X \"github.com/pingcap-incubator/tiup/pkg/localdata.DefaultTiupHome=#{var}/tiup\"", "cmd"
-    bin.install "bin/tiup"
+    # get current user
+    user = `whoami`
+    user.delete!("\n")
+    user.delete!("\r\n")
+
+    # home root path
+    root_ptah = if OS.mac?
+      "Users"
+    else
+      "/home"
+    end
+
+    home_path = root_ptah+"/"+user
+    # set real home path
+    if user == "root"
+      home_path = "/root"
+    end
+
+    # set HOME for tiup
+    ENV["HOME"] = home_path
+    #system "echo $HOME"
+
+    # cretae tiup home directory
+    tiup_home = home_path+"/"+".tiup"
+    # install
+    system "sh install.sh | grep -v 'shell' | grep -v 'profile' | grep -v 'playground' | grep -v '='"
+
+    # set tiup bin
+    bin_path = tiup_home+"/bin/tiup"
+    bin.install bin_path
+
+    #system "echo 'Installed path: ", tiup_home ,"'"
+  end
+
+  def upgrade
+    o = <<~EOS
+      Update all installed components to the latest version
+      ===============================================
+        Have a try:     tiup update --all
+      ===============================================
+
+      Questions? https://docs.pingcap.com/tidb/stable/tiup-component-management
+
+    EOS
+    
   end
 
   def caveats
     s = <<~EOS
+      To get started running a full TiDB Platform stack, with TiDB Server, TiKV Server, and PD, use tiup playground:
+      ===============================================
+        Have a try:     tiup playground
+      ===============================================
 
-      To get started running a full TiDB Platform stack, with
-      TiDB Server, TiKV Server, and PD, use tiup playground:
-
-        tiup run playground
-
-      Questions? https://pingcap.com/tidbslack/
+      Questions? https://docs.pingcap.com/tidb/stable/tiup-component-management
 
     EOS
     s
@@ -36,6 +81,6 @@ class Tiup < Formula
     #
     # The installed folder is not in the path, so use the entire path to any
     # executables being tested: `system "#{bin}/program", "do", "something"`.
-    system "false"
+    system "tiup" "--version"
   end
 end

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -18,7 +18,7 @@ class Tiup < Formula
 
     # home root path
     root_ptah = if OS.mac?
-      "Users"
+      "/Users"
     else
       "/home"
     end
@@ -29,24 +29,23 @@ class Tiup < Formula
       home_path = "/root"
     end
 
-    # set HOME for tiup
-    ENV["HOME"] = home_path
-    #system "echo $HOME"
+    #tiup_home = home_path+"/"+".tiup"
+    tiup_home = ENV["HOME"]+"/"+".tiup"
 
-    # cretae tiup home directory
-    tiup_home = home_path+"/"+".tiup"
     # install
     system "sh install.sh"
 
     # set tiup bin
     bin_path = tiup_home+"/bin/tiup"
+    #root_path = tiup_home+"/bin/root.json"
     bin.install bin_path
-
     #system "echo 'Installed path: ", tiup_home ,"'"
+    # end
   end
-
+  
   def upgrade
     o = <<~EOS
+
       Update all installed components to the latest version
       ===============================================
         Have a try:     tiup update --all
@@ -60,6 +59,12 @@ class Tiup < Formula
 
   def caveats
     s = <<~EOS
+      Install TiUP successfully!  Please run:
+      (If you have a private mirror source, Please replace https://tiup-mirrors.pingcap.com/root.json to your private mirror source:)
+      ===============================================
+        Must do: mkdir -p ~/.tiup/bin && curl https://tiup-mirrors.pingcap.com/root.json -o ~/.tiup/bin/root.json
+      ===============================================
+
       To get started running a full TiDB Platform stack, with TiDB Server, TiKV Server, and PD, use tiup playground:
       ===============================================
         Have a try:     tiup playground

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -4,7 +4,7 @@ class Tiup < Formula
   url "https://tiup-mirrors.pingcap.com/install.sh"
   sha256 "2784762fa6151539ecae3a975c21996036f4d7c82a4efe1f57dbefd1579c4b98"
   license "Apache-2.0"
-  version "1.7.0"
+  version "1.8.0"
 
   # depends_on "go" => :build
   depends_on "curl" => :build
@@ -39,6 +39,22 @@ class Tiup < Formula
     EOS
     s
   end
+
+  def upgrade
+    o = <<~EOS
+
+      Update all installed components to the latest version
+      
+      ===============================================
+        Have a try:     tiup update --self && tiup update cluster
+      ===============================================
+
+      Questions? https://docs.pingcap.com/tidb/stable/tiup-component-management
+
+    EOS
+    
+  end
+
 
   test do
     # `test do` will create, run in and delete a temporary directory.

--- a/Formula/tiup.rb
+++ b/Formula/tiup.rb
@@ -11,25 +11,7 @@ class Tiup < Formula
   depends_on "mysql-client" => :optional
 
   def install
-    # get current user
-    user = `whoami`
-    user.delete!("\n")
-    user.delete!("\r\n")
-
-    # home root path
-    root_ptah = if OS.mac?
-      "/Users"
-    else
-      "/home"
-    end
-
-    home_path = root_ptah+"/"+user
-    # set real home path
-    if user == "root"
-      home_path = "/root"
-    end
-
-    #tiup_home = home_path+"/"+".tiup"
+    # set tiup home
     tiup_home = ENV["HOME"]+"/"+".tiup"
 
     # install
@@ -47,6 +29,7 @@ class Tiup < Formula
     o = <<~EOS
 
       Update all installed components to the latest version
+      
       ===============================================
         Have a try:     tiup update --all
       ===============================================
@@ -60,15 +43,11 @@ class Tiup < Formula
   def caveats
     s = <<~EOS
       Install TiUP successfully!  Please run:
-      (If you have a private mirror source, Please replace https://tiup-mirrors.pingcap.com/root.json to your private mirror source:)
-      ===============================================
-        Must do: mkdir -p ~/.tiup/bin && curl https://tiup-mirrors.pingcap.com/root.json -o ~/.tiup/bin/root.json
-      ===============================================
+      (If you have a private mirror source, Please replace https://tiup-mirrors.pingcap.com/root.json to your private mirror source:)\
 
-      To get started running a full TiDB Platform stack, with TiDB Server, TiKV Server, and PD, use tiup playground:
-      ===============================================
-        Have a try:     tiup playground
-      ===============================================
+      ======================================================================
+      ! Must do:      mkdir -p ~/.tiup/bin && curl https://tiup-mirrors.pingcap.com/root.json -o ~/.tiup/bin/root.json
+      ======================================================================
 
       Questions? https://docs.pingcap.com/tidb/stable/tiup-component-management
 


### PR DESCRIPTION
https://github.com/pingcap/tiup/issues/1599

User can install tiup using brew, and it provides an easier start.
brew install pingcap/brew/tiup

The current official installation is installed in the current user's home directory by executing a script. In order to ensure the stability of the brew installation method, the installation method is also installed by stepping.
